### PR TITLE
 Import 'paikkatyyppi' as category

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,6 @@ var fs = require('fs');
 var argv = require('minimist')(process.argv.slice(2));
 var logger = require('pelias-logger').get('nlsfi-places-importer');
 
-processor.processData(argv['d'], function() {
+processor.processData(argv.d, function() {
   console.log("all done!");
 });

--- a/lib/readStream.js
+++ b/lib/readStream.js
@@ -9,8 +9,6 @@ var fs = require('fs'),
   logger = require('pelias-logger').get('nlsfi-places-importer'),
   adminLookupStream = require('./adminLookupStream');
 
-var admin = adminLookupStream.create();
-
 function processData(dir, callback) {
 
   var kunta_schema = fs.createReadStream(path.join(dir, "kunta.xsd"));
@@ -21,7 +19,12 @@ function processData(dir, callback) {
 
   function parsePaikat() {
 
-    var count = 0;
+    components.defineAdmin(kunnat, maakunnat, paikkatyypit);
+
+    var count = 0; // parsed
+    var prevcount = 0;
+    var inside = 0; // count of items entered our pipeline
+    var paused = false;
 
     // Create a file stream and pass it to XmlStream
     var stream = fs.createReadStream(path.join(dir, "paikka.xml"));
@@ -29,20 +32,36 @@ function processData(dir, callback) {
     var xml = new XmlStream(stream);
 
     var intervalId = setInterval(function() {
-      logger.info("Number of records parsed: " + count);
+      if (count>prevcount) {
+        logger.info("Number of records parsed: " + count);
+        prevcount=count;
+      }
     }, 10000);
 
     var r = through(function write(data) {
-      this.queue(data)
+      this.queue(data);
     }, function end() { //optional
-      this.queue(null)
+      this.queue(null);
       clearInterval(intervalId);
+    });
+
+    var sync = through(function write(data) {
+      this.queue(data);
+      inside++;
+      if(paused && count-inside<1000) {
+        paused=false;
+        xml.resume();
+      }
     });
 
     xml.on('endElement: pnr:Paikka', function(item) {
       // console.log("writing item", item);
       count++;
       r.write(item);
+      if(!paused && count-inside>10000) {
+        xml.pause();
+        paused=true;
+      }
     });
 
     xml.collect("pnr:nimi");
@@ -52,12 +71,13 @@ function processData(dir, callback) {
       r.end();
     });
 
-    r.pipe(components.createPaikkatyyppiAlaryhmaFilter())
+    r.pipe(sync)
+      .pipe(components.createPaikkatyyppiAlaryhmaFilter())
       .pipe(components.createNameConverter())
       .pipe(components.createCoordinateConverter())
       .pipe(components.createTypeMapper())
       .pipe(components.createDocumentGenerator())
-      .pipe(admin)
+      .pipe(adminLookupStream.create())
       .pipe(model.createDocumentMapperStream())
       .pipe(peliasDbClient())
       .on('finish', callback);

--- a/lib/readStream.js
+++ b/lib/readStream.js
@@ -1,3 +1,4 @@
+
 var fs = require('fs'),
   path = require('path'),
   XmlStream = require('xml-stream'),
@@ -14,11 +15,11 @@ function processData(dir, callback) {
 
   var kunta_schema = fs.createReadStream(path.join(dir, "kunta.xsd"));
   var maakunta_schema = fs.createReadStream(path.join(dir, "maakunta.xsd"));
+  var paikkatyyppi_schema = fs.createReadStream(path.join(dir, "paikkatyyppi.xsd"));
 
-  var kunnat, maakunnat;
+  var kunnat, maakunnat, paikkatyypit;
 
   function parsePaikat() {
-    components.defineAdmin(kunnat, maakunnat);
 
     var count = 0;
 
@@ -70,11 +71,17 @@ function processData(dir, callback) {
   function kunnatDone(k) {
     kunnat = k;
     require('./schema-parser')(maakunta_schema, maakunnatDone);
-  };
+  }
 
-  require('./schema-parser')(kunta_schema, kunnatDone);
+
+  function paikkatyypitDone(pt) {
+    paikkatyypit = pt;
+    require('./schema-parser')(kunta_schema, kunnatDone);
+  }
+
+  require('./schema-parser')(paikkatyyppi_schema, paikkatyypitDone);
 }
 
 module.exports = {
   processData: processData
-}
+};

--- a/lib/readStream.js
+++ b/lib/readStream.js
@@ -45,10 +45,20 @@ function processData(dir, callback) {
       clearInterval(intervalId);
     });
 
+    /* Import pipeline is by default badly unbalanced: for some reason XML parser gets most CPU time
+       and eats all memory by continuously pushing new records into the rest of the pipeline which does
+       not get much processing time. One reason to this is that xml-parser is not connected to import
+       using the usual pipe method but writes explicitly from a parsing callback. This apparently breaks
+       stream's pause/resume mechanism.
+
+       Fortunately, xml-stream has a pausing control. So we simply count parsed records and records, which
+       have entered the pipeline. If the difference grows too big, we halt the parsing until the pipeline
+       has consumed the buffered records.
+    */
     var sync = through(function write(data) {
       this.queue(data);
       inside++;
-      if(paused && count-inside<1000) {
+      if(paused && count-inside<1000) { // pipeline is empty enough, resume parsing
         paused=false;
         xml.resume();
       }
@@ -58,7 +68,7 @@ function processData(dir, callback) {
       // console.log("writing item", item);
       count++;
       r.write(item);
-      if(!paused && count-inside>10000) {
+      if(!paused && count-inside>10000) { // parser is getting too far ahead, slow down
         xml.pause();
         paused=true;
       }

--- a/lib/readStreamComponents.js
+++ b/lib/readStreamComponents.js
@@ -5,12 +5,13 @@ var proj4 = require('proj4');
 var Document = require('pelias-model').Document;
 var logger = require('pelias-logger').get('nlsfi-places-importer');
 
-var kunnat, maakunnat;
+var kunnat, maakunnat, paikkatyypit;
 
 // must be called before - use - of stream components below
-function defineAdmin(_kunnat, _maakunnat) {
+function defineAdmin(_kunnat, _maakunnat, _paikkatyypit) {
   kunnat = _kunnat;
   maakunnat = _maakunnat;
+  paikkatyypit = _paikkatyypit;
 }
 
 /**
@@ -25,7 +26,33 @@ function createTypeMapper() {
     '575': 'region',
     '580': 'region',
     '120': 'station'
-  }
+  };
+
+  return map_stream.obj(function(record) {
+    var koodi = record['pnr:paikkatyyppiKoodi'];
+    if(types[koodi]) {
+      record.type = types[koodi];
+    } else {
+      var tyyppi = paikkatyypit[koodi];
+      record.category=tyyppi[2]; // english version
+    }
+    return record;
+  });
+}
+
+/**
+ * Map paikkatyyppi to type
+ */
+function createTypeMapper() {
+
+  var types = {
+    '540': 'localadmin',
+    '550': 'localadmin',
+    '560': 'neighbourhood',
+    '575': 'region',
+    '580': 'region',
+    '120': 'station'
+  };
 
   return map_stream.obj(function(record) {
     record.type = types[record['pnr:paikkatyyppiKoodi']];
@@ -46,7 +73,7 @@ function createCoordinateConverter() {
   return map_stream.obj(function(record) {
     var location = record['pnr:paikkaSijainti']['gml:Point']['gml:pos'];
     var srcCoords = location.split(' ').map(function(n) {
-      return Number(n)
+      return Number(n);
     });
     var dstCoords = proj4('EPSG:3067', 'WGS84', srcCoords);
     record.lat = dstCoords[1];
@@ -124,24 +151,25 @@ var createDocumentGenerator = function() {
     if(type !== 'localadmin' && type !== 'region') {
       for(var i in kunta) {
         try { mmlDoc.addParent('localadmin', kunta[i].text, kuntaKoodi); }
-        catch (err) { logger.info('invalid localadmin', err) }
+        catch (err) { logger.info('invalid localadmin', err); }
       }
     }
 
     if(type !== 'region') {
-      for(var i in maakunta) {
-        try { mmlDoc.addParent('region', maakunta[i].text, maakuntaKoodi); }
-        catch(err) { logger.info('invalid region', err) }
+      for(var j in maakunta) {
+        try { mmlDoc.addParent('region', maakunta[j].text, maakuntaKoodi); }
+        catch(err) { logger.info('invalid region', err); }
       }
     }
 
-    /* not needed, WOF will add country=Finland
+    if(record.category) {
+      mmlDoc.addCategory(record.category);
+    }
     try { mmlDoc.addParent('country', 'Finland', "85633143", "FIN"); }
     catch(err) { logger.info('invalid country', err); }
 
     try { mmlDoc.addParent('country', 'Suomi', "85633143", "FIN"); }
     catch(err) { logger.info('invalid country', err); }
-    */
 
     //  logger.info('MmlDoc: ', JSON.stringify(mmlDoc));
     return mmlDoc;

--- a/lib/readStreamComponents.js
+++ b/lib/readStreamComponents.js
@@ -34,28 +34,8 @@ function createTypeMapper() {
       record.type = types[koodi];
     } else {
       var tyyppi = paikkatyypit[koodi];
-      record.category=tyyppi[2]; // english version
+      record.category=tyyppi[2].text; // english version
     }
-    return record;
-  });
-}
-
-/**
- * Map paikkatyyppi to type
- */
-function createTypeMapper() {
-
-  var types = {
-    '540': 'localadmin',
-    '550': 'localadmin',
-    '560': 'neighbourhood',
-    '575': 'region',
-    '580': 'region',
-    '120': 'station'
-  };
-
-  return map_stream.obj(function(record) {
-    record.type = types[record['pnr:paikkatyyppiKoodi']];
     return record;
   });
 }

--- a/lib/schema-parser.js
+++ b/lib/schema-parser.js
@@ -1,5 +1,5 @@
 var fs = require('fs'),
-  XmlStream = require('xml-stream')
+    XmlStream = require('xml-stream');
 
 function getEnumerations(stream, callback) {
 
@@ -12,8 +12,8 @@ function getEnumerations(stream, callback) {
 
     var code = item['$']['value'];
     var names = item['xsd:annotation']['xsd:documentation'].map(function(documentation) {
-      var lang = documentation["$"]["xml:lang"]
-      var text = documentation["$text"]
+      var lang = documentation["$"]["xml:lang"];
+      var text = documentation["$text"];
       return {
         lang: lang,
         text: text
@@ -27,4 +27,4 @@ function getEnumerations(stream, callback) {
   });
 }
 
-module.exports = getEnumerations
+module.exports = getEnumerations;


### PR DESCRIPTION
Paikkatyyppi, which does not fit into pelias type/layer categorization, is now stored as a category label. For example, Kärsäsmäki (kohouma) can now be understood better.

This PR also fixes the nasty import stream buffering problem, which exhausted the memory.
