### PR TITLE
DT-4673: do not import mml stations

### DIFF
--- a/lib/blacklist.js
+++ b/lib/blacklist.js
@@ -14,7 +14,7 @@ module.exports = function() {
     }
   }
   return through.obj(function( record, enc, next ) {
-    if (!blacklist[record.getId()]) {
+    if (!blacklist[record.getId()] && record.getLayer() !== 'station') {
       this.push(record);
     } else {
       removed++;


### PR DESCRIPTION
They are all railway stations. Active stations are also imported from GTFS data.
MML data includes about 300 additional stations, which all are no longer in use or used
for cargo traffic only. The data does not tell difference between active and inactive stations,
and generic names like 'jämsänkoski, jämsä' neither indicate museum status. Such stations are
just confusing without any context reference, so it is best not to import them at all.